### PR TITLE
fix: save package in devDependencies

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,9 @@
   },
   "schematics": "./collection.json",
   "builders": "./builders.json",
+  "ng-add": {
+    "save": "devDependencies"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/angular-schule/angular-cli-ghpages.git"


### PR DESCRIPTION
In the latest versions of the CLI `ng-add` packages can be added to `devDependencies` and this package is perfect for such use case since it's only needed for development.

See: https://github.com/angular/angular-cli/pull/15815