### PR TITLE
fix: throws an error if app building fails

### DIFF
--- a/src/deploy/actions.ts
+++ b/src/deploy/actions.ts
@@ -30,7 +30,11 @@ export default async function deploy(
       project: context.target.project,
       configuration
     }, overrides as json.JsonObject);
-    await build.result;
+    const buildResult = await build.result;
+
+    if (!buildResult.success) {
+      throw new Error(buildResult.error);
+    }
   }
 
   await engine.run(


### PR DESCRIPTION
I am generating this pull request w.r.t this Issue #74.

I think that this issue is caused by [actions.ts#L33](https://github.com/angular-schule/angular-cli-ghpages/blob/master/src/deploy/actions.ts#L33). The result has ```success``` and ```error``` properties, but they seem to be ignored in the line.

I have added two changes in this PR.
- add a test to check app building failure
- throw an error if app building fails