### PR TITLE
fix(engine): remove extraneous slash from extended commit message for GitHub Actions

### DIFF
--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -113,7 +113,6 @@ export async function prepareOptions(
       '\n\n' +
       'Triggered by commit: https://github.com/' +
       process.env.GITHUB_REPOSITORY +
-      '/' +
       '/commit/' +
       process.env.GITHUB_SHA;
   }


### PR DESCRIPTION
Currently, in `0.6.2` of `angular-cli-ghpages`, the extended commit message for GitHub Actions has an extraneous slash in the URL. Fortunately, the extra slash does not break the URL.

This PR simply removes the extra slash in the URL.

Before:

```
<commit message>

Triggered by commit: https://github.com/EdricChan03/rss-reader//commit/d8b3b445e1963df9075b97d691609f9f19da9626
```

After:

```
<commit message>

Triggered by commit: https://github.com/EdricChan03/rss-reader/commit/d8b3b445e1963df9075b97d691609f9f19da9626
```

See https://github.com/EdricChan03/rss-reader/commit/14f9b0241816d4bba8233c2937823d1632dd1efe for an example.

P.S. Could there be added tests for the extended commit messages to verify that they work?