### PR TITLE
Display GitHub Pages URL after ng deploy

### DIFF
--- a/src/engine/defaults.ts
+++ b/src/engine/defaults.ts
@@ -10,6 +10,6 @@ export const defaults = {
   cname: undefined,
   dryRun: false,
   remote: 'origin',
-  pages: '',
+  ghPagesUrl: '',
   git: 'git'
 };

--- a/src/engine/defaults.ts
+++ b/src/engine/defaults.ts
@@ -10,5 +10,6 @@ export const defaults = {
   cname: undefined,
   dryRun: false,
   remote: 'origin',
+  pages: '',
   git: 'git'
 };

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -95,6 +95,17 @@ describe('engine', () => {
       );
     });
 
+    it('should discover the github pages url from url w/o .git suffix', async () => {
+      const options = {
+        repo: 'https://github.com/organisation/your-repo'
+      };
+      const finalOptions = await engine.prepareOptions(options, logger);
+
+      expect(finalOptions.ghPagesUrl).toBe(
+        'https://organisation.github.io/your-repo'
+      );
+    });
+
     it('should discover the github pages url from ssh repository url', async () => {
       const options = {
         repo: 'git@github.com:organisation/your-repo.git'

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -91,7 +91,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo '
+        'https://organisation.github.io/your-repo'
       );
     });
 
@@ -102,7 +102,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo '
+        'https://organisation.github.io/your-repo'
       );
     });
 
@@ -113,7 +113,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo '
+        'https://organisation.github.io/your-repo'
       );
     });
 
@@ -124,7 +124,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo '
+        'https://organisation.github.io/your-repo'
       );
     });
 
@@ -135,7 +135,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/x.gity '
+        'https://organisation.github.io/x.gity'
       );
     });
 

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -106,6 +106,17 @@ describe('engine', () => {
       );
     });
 
+    it('should discover the github pages url from url that ends with splash', async () => {
+      const options = {
+        repo: 'https://github.com/organisation/your-repo/'
+      };
+      const finalOptions = await engine.prepareOptions(options, logger);
+
+      expect(finalOptions.ghPagesUrl).toBe(
+        'https://organisation.github.io/your-repo'
+      );
+    });
+
     it('should discover the github pages url from ssh repository url', async () => {
       const options = {
         repo: 'git@github.com:organisation/your-repo.git'

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -91,7 +91,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo'
+        'https://organisation.github.io/your-repo '
       );
     });
 
@@ -102,7 +102,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo'
+        'https://organisation.github.io/your-repo '
       );
     });
 
@@ -113,7 +113,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo'
+        'https://organisation.github.io/your-repo '
       );
     });
 
@@ -124,7 +124,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/your-repo'
+        'https://organisation.github.io/your-repo '
       );
     });
 
@@ -135,7 +135,7 @@ describe('engine', () => {
       const finalOptions = await engine.prepareOptions(options, logger);
 
       expect(finalOptions.ghPagesUrl).toBe(
-        'https://organisation.github.io/x.gity'
+        'https://organisation.github.io/x.gity '
       );
     });
 

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -90,7 +90,7 @@ describe('engine', () => {
       };
       const finalOptions = await engine.prepareOptions(options, logger);
 
-      expect(finalOptions.pages).toBe(
+      expect(finalOptions.ghPagesUrl).toBe(
         'https://organisation.github.io/your-repo'
       );
     });
@@ -101,7 +101,7 @@ describe('engine', () => {
       };
       const finalOptions = await engine.prepareOptions(options, logger);
 
-      expect(finalOptions.pages).toBe(
+      expect(finalOptions.ghPagesUrl).toBe(
         'https://organisation.github.io/your-repo'
       );
     });
@@ -112,7 +112,9 @@ describe('engine', () => {
       };
       const finalOptions = await engine.prepareOptions(options, logger);
 
-      expect(finalOptions.pages).toBe('https://organisation.github.io/x.gity');
+      expect(finalOptions.ghPagesUrl).toBe(
+        'https://organisation.github.io/x.gity'
+      );
     });
 
     /*

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -84,6 +84,37 @@ describe('engine', () => {
       expect(finalOptions.repo).toMatch(/angular-schule\/angular-cli-ghpages/);
     });
 
+    it('should discover the github pages url from https repository url', async () => {
+      const options = {
+        repo: 'https://github.com/organisation/your-repo.git'
+      };
+      const finalOptions = await engine.prepareOptions(options, logger);
+
+      expect(finalOptions.pages).toBe(
+        'https://organisation.github.io/your-repo'
+      );
+    });
+
+    it('should discover the github pages url from ssh repository url', async () => {
+      const options = {
+        repo: 'git@github.com:organisation/your-repo.git'
+      };
+      const finalOptions = await engine.prepareOptions(options, logger);
+
+      expect(finalOptions.pages).toBe(
+        'https://organisation.github.io/your-repo'
+      );
+    });
+
+    it('should discover the github pages url from https repository url that contains with `.git`', async () => {
+      const options = {
+        repo: 'https://github.com/organisation/x.gity.git'
+      };
+      const finalOptions = await engine.prepareOptions(options, logger);
+
+      expect(finalOptions.pages).toBe('https://organisation.github.io/x.gity');
+    });
+
     /*
     // i was not able to somehow catch an error... :-(
     it('should should throw an exception, if remote url could not be discovered', async () => {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -32,7 +32,7 @@ export async function run(
   await publishViaGhPages(ghpages, dir, options, logger);
 
   logger.info(
-    '🚀 Successfully published via angular-cli-ghpages! Have a nice day!'
+    `🚀 Successfully published ${options.pages} via angular-cli-ghpages! Have a nice day!`
   );
 }
 
@@ -156,6 +156,13 @@ export async function prepareOptions(
         'https://github.com/',
         `https://x-access-token:${process.env.GITHUB_TOKEN}@github.com/`
       );
+    }
+  }
+
+  if (options.repo) {
+    const match = options.repo.match(/github.com(\/|:)(.*)\/(.*)\.git$/);
+    if (match) {
+      options.pages = `https://${match[2]}.github.io/${match[3]}`;
     }
   }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -32,7 +32,7 @@ export async function run(
   await publishViaGhPages(ghpages, dir, options, logger);
 
   logger.info(
-    `🚀 Successfully published ${options.ghPagesUrl} via angular-cli-ghpages! Have a nice day!`
+    `🚀 Successfully published ${options.ghPagesUrl}via angular-cli-ghpages! Have a nice day!`
   );
 }
 
@@ -293,7 +293,7 @@ function tryParseGhPagesUrl(options: any): any {
     /github.com(\/|:)(.*)\/(.*)$/
   );
   if (matchEndsWithRepoName) {
-    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]}`;
+    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]} `;
     return options;
   }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -285,16 +285,11 @@ async function getRemoteUrl(options) {
 
 function tryParseGhPagesUrl(options: any): any {
   // Not assume custom domain page
+  let trimEndDotGit = options.repo
+    .replace(/\/\s*$/, '')
+    .replace(/\.git\s*$/, '');
 
-  const matchEndsWithDotGit = options.repo.match(
-    /github.com(\/|:)(.*)\/(.*)\.git$/
-  );
-  if (matchEndsWithDotGit) {
-    options.ghPagesUrl = `https://${matchEndsWithDotGit[2]}.github.io/${matchEndsWithDotGit[3]}`;
-    return options;
-  }
-
-  const matchEndsWithRepoName = options.repo.match(
+  const matchEndsWithRepoName = trimEndDotGit.match(
     /github.com(\/|:)(.*)\/(.*)$/
   );
   if (matchEndsWithRepoName) {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -160,11 +160,7 @@ export async function prepareOptions(
   }
 
   if (options.repo) {
-    // Not assume custom domain page
-    const match = options.repo.match(/github.com(\/|:)(.*)\/(.*)\.git$/);
-    if (match) {
-      options.ghPagesUrl = `https://${match[2]}.github.io/${match[3]}`;
-    }
+    return tryParseGhPagesUrl(options);
   }
 
   return options;
@@ -285,4 +281,26 @@ async function publishViaGhPages(
 async function getRemoteUrl(options) {
   const git = new Git(process.cwd(), options.git);
   return await git.getRemoteUrl(options.remote);
+}
+
+function tryParseGhPagesUrl(options: any): any {
+  // Not assume custom domain page
+
+  const matchEndsWithDotGit = options.repo.match(
+    /github.com(\/|:)(.*)\/(.*)\.git$/
+  );
+  if (matchEndsWithDotGit) {
+    options.ghPagesUrl = `https://${matchEndsWithDotGit[2]}.github.io/${matchEndsWithDotGit[3]}`;
+    return options;
+  }
+
+  const matchEndsWithRepoName = options.repo.match(
+    /github.com(\/|:)(.*)\/(.*)$/
+  );
+  if (matchEndsWithRepoName) {
+    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]}`;
+    return options;
+  }
+
+  return options;
 }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -32,7 +32,7 @@ export async function run(
   await publishViaGhPages(ghpages, dir, options, logger);
 
   logger.info(
-    `🚀 Successfully published ${options.ghPagesUrl}via angular-cli-ghpages! Have a nice day!`
+    `🚀 Successfully published ${options.ghPagesUrl} via angular-cli-ghpages! Have a nice day!`
   );
 }
 
@@ -293,7 +293,7 @@ function tryParseGhPagesUrl(options: any): any {
     /github.com(\/|:)(.*)\/(.*)$/
   );
   if (matchEndsWithRepoName) {
-    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]} `;
+    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]}`;
     return options;
   }
 

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -160,7 +160,14 @@ export async function prepareOptions(
   }
 
   if (options.repo) {
-    return tryParseGhPagesUrl(options);
+    // Not assume custom domain page
+    let trimEndDotGit = options.repo
+      .replace(/\/\s*$/, '')
+      .replace(/\.git\s*$/, '');
+    const matchEndsWithRepoName = trimEndDotGit.match(/github.com(\/|:)(.*)\/(.*)$/);
+    if (matchEndsWithRepoName) {
+      options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]}`;
+    }
   }
 
   return options;
@@ -281,21 +288,4 @@ async function publishViaGhPages(
 async function getRemoteUrl(options) {
   const git = new Git(process.cwd(), options.git);
   return await git.getRemoteUrl(options.remote);
-}
-
-function tryParseGhPagesUrl(options: any): any {
-  // Not assume custom domain page
-  let trimEndDotGit = options.repo
-    .replace(/\/\s*$/, '')
-    .replace(/\.git\s*$/, '');
-
-  const matchEndsWithRepoName = trimEndDotGit.match(
-    /github.com(\/|:)(.*)\/(.*)$/
-  );
-  if (matchEndsWithRepoName) {
-    options.ghPagesUrl = `https://${matchEndsWithRepoName[2]}.github.io/${matchEndsWithRepoName[3]}`;
-    return options;
-  }
-
-  return options;
 }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -32,7 +32,7 @@ export async function run(
   await publishViaGhPages(ghpages, dir, options, logger);
 
   logger.info(
-    `🚀 Successfully published ${options.pages} via angular-cli-ghpages! Have a nice day!`
+    `🚀 Successfully published ${options.ghPagesUrl} via angular-cli-ghpages! Have a nice day!`
   );
 }
 
@@ -160,9 +160,10 @@ export async function prepareOptions(
   }
 
   if (options.repo) {
+    // Not assume custom domain page
     const match = options.repo.match(/github.com(\/|:)(.*)\/(.*)\.git$/);
     if (match) {
-      options.pages = `https://${match[2]}.github.io/${match[3]}`;
+      options.ghPagesUrl = `https://${match[2]}.github.io/${match[3]}`;
     }
   }
 


### PR DESCRIPTION
I am generating this pull request w.r.t this Issue #94.

In this PR, I have one limitation: I assume only 'github.io' pages. Custom domain page is not intended.
For custom domain page users, unexpected url would be displayed.