### PR TITLE
chore: change default commit message to "...[ci ckip]"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,4 @@ jobs:
         run: |
           cd src
           cd your-angular-project
-          ng deploy --no-silent --message="Auto-generated commit [ci skip]" --name="The Buildbot" --email="buildbot@angular2buch.de"
+          ng deploy --no-silent --name="The Buildbot" --email="buildbot@angular2buch.de"

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Learn more about ["personal access tokens" here](https://help.github.com/article
 #### --message <a name="message"></a>
 
 - **optional**
-- Default: `Auto-generated commit` (string)
+- Default: `Auto-generated commit [ci skip]` (string)
 - Example: `ng deploy --message="What could possibly go wrong?"`
 
 The commit message **must be wrapped in quotes** if there are any spaces in the text.  

--- a/docs/README_standalone.md
+++ b/docs/README_standalone.md
@@ -111,7 +111,7 @@ you can provide the repository URL in the `repo` option.
 
 #### --message <a name="message"></a>
  * __optional__
- * Default: `Auto-generated commit`
+ * Default: `Auto-generated commit [ci skip]`
  * Example: `npx angular-cli-ghpages --message="What could possibly go wrong?"`
 
 The commit message, __must be wrapped in quotes__.  

--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -23,7 +23,7 @@
     "message": {
       "type": "string",
       "description": "The commit message.",
-      "default": "Auto-generated commit"
+      "default": "Auto-generated commit [ci skip]"
     },
     "branch": {
       "type": "string",

--- a/src/engine/defaults.ts
+++ b/src/engine/defaults.ts
@@ -1,7 +1,7 @@
 export const defaults = {
   dir: 'dist',
   repo: undefined,
-  message: 'Auto-generated commit',
+  message: 'Auto-generated commit [ci skip]',
   branch: 'gh-pages',
   name: undefined,
   email: undefined,


### PR DESCRIPTION
I assume that nobody wants to build a `gh-pages` branch on a CI environment.
This should work on a lot of environments by default and can be still changed very easily.

fixes #111