### PR TITLE
fix: remove deprecated JSON parser, use workspace helpers

### DIFF
--- a/src/__snapshots__/ng-add.spec.ts.snap
+++ b/src/__snapshots__/ng-add.spec.ts.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ng-add generating files generates new files if starting from scratch 1`] = `
+"{
+  \\"version\\": 1,
+  \\"defaultProject\\": \\"THEPROJECT\\",
+  \\"projects\\": {
+    \\"THEPROJECT\\": {
+      \\"projectType\\": \\"application\\",
+      \\"root\\": \\"PROJECTROOT\\",
+      \\"architect\\": {
+        \\"build\\": {
+          \\"options\\": {
+            \\"outputPath\\": \\"dist/THEPROJECT\\"
+          }
+        },
+        \\"deploy\\": {
+          \\"builder\\": \\"angular-cli-ghpages:deploy\\"
+        }
+      }
+    },
+    \\"OTHERPROJECT\\": {
+      \\"projectType\\": \\"application\\",
+      \\"root\\": \\"PROJECTROOT\\",
+      \\"architect\\": {
+        \\"build\\": {
+          \\"options\\": {
+            \\"outputPath\\": \\"dist/OTHERPROJECT\\"
+          }
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`ng-add generating files overrides existing files 1`] = `
+"{
+  \\"version\\": 1,
+  \\"defaultProject\\": \\"THEPROJECT\\",
+  \\"projects\\": {
+    \\"THEPROJECT\\": {
+      \\"projectType\\": \\"application\\",
+      \\"root\\": \\"PROJECTROOT\\",
+      \\"architect\\": {
+        \\"build\\": {
+          \\"options\\": {
+            \\"outputPath\\": \\"dist/THEPROJECT\\"
+          }
+        },
+        \\"deploy\\": {
+          \\"builder\\": \\"angular-cli-ghpages:deploy\\"
+        }
+      }
+    },
+    \\"OTHERPROJECT\\": {
+      \\"projectType\\": \\"application\\",
+      \\"root\\": \\"PROJECTROOT\\",
+      \\"architect\\": {
+        \\"build\\": {
+          \\"options\\": {
+            \\"outputPath\\": \\"dist/OTHERPROJECT\\"
+          }
+        },
+        \\"deploy\\": {
+          \\"builder\\": \\"angular-cli-ghpages:deploy\\"
+        }
+      }
+    }
+  }
+}"
+`;

--- a/src/deploy/actions.ts
+++ b/src/deploy/actions.ts
@@ -2,7 +2,7 @@ import {
   BuilderContext,
   targetFromTargetString
 } from '@angular-devkit/architect';
-import { json, logging } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 
 import { Schema } from './schema';
 import { BuildTarget } from '../interfaces';

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -50,9 +50,9 @@
   },
   "homepage": "https://github.com/angular-schule/angular-cli-ghpages/#readme",
   "devDependencies": {
-    "@angular-devkit/architect": ">= 0.900 < 0.1300",
-    "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-    "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+    "@angular-devkit/architect": ">= 0.900 < 0.1400",
+    "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "@types/fs-extra": "^9.0.4",
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.7",
@@ -67,9 +67,9 @@
     "typescript": ">=4.0.0 <4.1.0"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": ">= 0.900 < 0.1300",
-    "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-    "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "@angular-devkit/architect": ">= 0.900 < 0.1400",
+    "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+    "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   },
   "dependencies": {
     "commander": "^3.0.0-0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "description": "Deploy your Angular app to GitHub pages directly from the Angular CLI. (ng deploy)",
   "main": "index.js",
   "bin": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,23 @@
+import { virtualFs, workspaces } from '@angular-devkit/core';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+
+export function createHost(tree: Tree): workspaces.WorkspaceHost {
+  return {
+    async readFile(path: string): Promise<string> {
+      const data = tree.read(path);
+      if (!data) {
+        throw new SchematicsException('File not found.');
+      }
+      return virtualFs.fileBufferToString(data);
+    },
+    async writeFile(path: string, data: string): Promise<void> {
+      return tree.overwrite(path, data);
+    },
+    async isDirectory(path: string): Promise<boolean> {
+      return !tree.exists(path) && tree.getDir(path).subfiles.length > 0;
+    },
+    async isFile(path: string): Promise<boolean> {
+      return tree.exists(path);
+    }
+  };
+}


### PR DESCRIPTION
fix #138 . This also SEEMS to fix issue #137 – at least I didn't get any similar errors.

Things worth to know:
- reading/writing the workspace has completely moved to the builtin helpers
- some error messages have changed
- the empty options object is automatically removed. We could statically add one option there so that the object is not empty.

see also: https://angular.io/guide/schematics-for-libraries#define-a-generation-rule