### PR TITLE
build: create a separate tsconfig file for build by @dianjuar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2020 Johannes Hoppe
+Copyright (c) 2017-2021 Johannes Hoppe
 Copyright (c) 2019 Minko Gechev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/package.json
+++ b/src/package.json
@@ -8,7 +8,9 @@
     "ngh": "angular-cli-ghpages"
   },
   "scripts": {
-    "build": "rimraf dist && json2ts deploy/schema.json > deploy/schema.d.ts && tsc && copyfiles builders.json collection.json ng-add-schema.json package.json angular-cli-ghpages deploy/schema.json dist && copyfiles ../README.md dist/README.md",
+    "prebuild": "rimraf dist && json2ts deploy/schema.json > deploy/schema.d.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "postbuild": "copyfiles builders.json collection.json ng-add-schema.json package.json angular-cli-ghpages deploy/schema.json dist && copyfiles ../README.md dist/README.md",
     "test": "jest",
     "prettier": "prettier --write ."
   },

--- a/src/tsconfig.build.json
+++ b/src/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "**/*spec.ts"]
+}


### PR DESCRIPTION
@dianjuar wrote in the ngx-deploy-starter repo:

> I've seen that is a common practice between typescript projects to have separate tsconfig files, Angular and Nest do that.
> 
> Also, I've been discovering some improvements using this configuration on [my fork](https://github.com/bikecoders/ngx-deploy-npm):
> 
> ### The build is independent for the test
> Currently, if there is a typo on the test, the build fails due to a compilation error. Very inconvenient when you are making some experiments and want to try them.
> 
> ### The tests are not being compiled and added to the dist
> On the final build, there is no need to put the test, they are useless there. This makes the compilation time faster _(0.02 sec faster on my machine 🤓)_ and the final library lighter.



see https://github.com/angular-schule/ngx-deploy-starter/pull/28