### PR TITLE
fix: bump `@angular-devkit/architect` version range

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/angular-schule/angular-cli-ghpages/#readme",
   "devDependencies": {
-    "@angular-devkit/architect": ">= 0.900 < 0.1500",
+    "@angular-devkit/architect": ">= 0.900 < 0.1600",
     "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
     "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
     "@types/fs-extra": "^9.0.4",
@@ -71,7 +71,7 @@
     "typescript": ">=4.2.3 <4.3.0"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": ">= 0.900 < 0.1500",
+    "@angular-devkit/architect": ">= 0.900 < 0.1600",
     "@angular-devkit/core": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
     "@angular-devkit/schematics": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
   },


### PR DESCRIPTION
Fixes a regression (#158) where the package could not be installed due to a peer dependencies conflict on Angular v15.

(This just updates the version range - I've not tested it locally)