### PR TITLE
fix: fix wrong default value for `cname` option in `schema.json`

### DIFF
--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -51,7 +51,7 @@
     "cname": {
       "type": "string",
       "description": "Generate a CNAME file for the specified domain.",
-      "default": false
+      "default": ""
     },
     "dryRun": {
       "type": "boolean",


### PR DESCRIPTION
Closes #145