### PR TITLE
Update example to recent version of actions and Node.js v20

### DIFF
--- a/docs/README_environment_github_actions.md
+++ b/docs/README_environment_github_actions.md
@@ -50,12 +50,12 @@ More info can be found here:
 
        steps:
          - name: Checkout
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
 
-         - name: Use Node.js 16.x
-           uses: actions/setup-node@v3
+         - name: Use Node.js 20.x
+           uses: actions/setup-node@v4
            with:
-             node-version: 16.x
+             node-version: 20.x
              cache: "npm"
 
          - name: Prepare and deploy


### PR DESCRIPTION
Node.js 16 is almost deprecated and cause warning:

> [build-and-deploy]
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.