### PR TITLE
Add one more step to run tests and deploy only if tests are passing

### DIFF
--- a/docs/README_environment_github_actions.md
+++ b/docs/README_environment_github_actions.md
@@ -71,7 +71,7 @@ More info can be found here:
    ```
 
 6. Make sure to replace **`/the-repository-name/`**, **`Displayed Username`** and **`mail@example.org`** with correct values in above snippet.
-7. If you do not have tests you may remove step "Run tests" from the example.
+7. If you do not have tests you may remove the step "Run tests" from the example.
 8. You can also control when your workflows are triggered:
 
    - It can be helpful to not have your workflows run on every push to every branch in the repo.


### PR DESCRIPTION
There might be lots of different tests. This example is based on Angular 17 suggestion - https://angular.dev/guide/testing#testing-in-continuous-integration

With separate steps it should be easier to figure out what is failed.