### PR TITLE
Added --remote option

### DIFF
--- a/docs/README_standalone.md
+++ b/docs/README_standalone.md
@@ -88,6 +88,16 @@ and that you want to push changes to the `origin` remote.
 If instead, your files are not in a git repository, or if you want to push to another repository,
 you can provide the repository URL in the `repo` option.
 
+#### --remote <a name="remote"></a>
+
+- **optional**
+- Default: `origin`
+- Example: `npx angular-cli-ghpages --remote=github`
+
+By default, **gh-pages** assumes that the current working directory is a git repository,
+and that you want to push changes to the `origin` remote.
+If you want to push to another remote, you can provide the remote name in the `remote` option.
+
 #### --message <a name="message"></a>
 
 - **optional**

--- a/src/angular-cli-ghpages
+++ b/src/angular-cli-ghpages
@@ -25,6 +25,11 @@ commander
     defaults.repo
   )
   .option(
+    '-R, --remote <remote>',
+    'Provide the remote name. If no value is provided, and --repo is not set, `origin` is used.',
+    defaults.remote
+  )
+  .option(
     '-m, --message <message>',
     'The commit message, must be wrapped in quotes.',
     defaults.message

--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -24,6 +24,10 @@
       "default": false,
       "description": "Skip build process during deployment."
     },
+    "remote": {
+      "type": "string",
+      "description": "Provide the remote name. If no value is provided, and --repo is not set, `origin` is used."
+    },
     "repo": {
       "type": "string",
       "description": "Provide the repository URL. If no value is provided, the `origin` remote of the current working directory is used."


### PR DESCRIPTION
I don't use `origin` as my primary remote and I didn't want to use the `--repo` option every time, so I added a `--remote` option.