### PR TITLE
refactor: remove fs-extra, use native fs/promises

### DIFF
--- a/src/engine/engine.gh-pages-clean.spec.ts
+++ b/src/engine/engine.gh-pages-clean.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * gh-pages.clean() behavior verification
+ *
+ * What we're testing:
+ * - gh-pages.clean() actually removes cache directories
+ * - This catches breaking changes if gh-pages updates its behavior
+ *
+ * Why maxWorkers: 1 is required:
+ * gh-pages uses a globally shared cache at node_modules/.cache/gh-pages/
+ * The clean() function is a nuclear option - it wipes the ENTIRE cache directory:
+ *
+ *   exports.clean = function clean() {
+ *     fs.removeSync(getCacheDir());  // Removes ALL repo caches at once!
+ *   };
+ *
+ * If tests run in parallel, one test's clean() call destroys caches that
+ * other tests are actively using, causing random failures.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+import { pathExists } from '../utils';
+
+const ghPages = require('gh-pages');
+const findCacheDir = require('find-cache-dir');
+const filenamify = require('filenamify');
+
+describe('gh-pages.clean() behavior', () => {
+
+  it('should remove repo-specific cache directories', async () => {
+    const cacheBaseDir = findCacheDir({ name: 'gh-pages' });
+    if (!cacheBaseDir) {
+      // Skip if no cache dir available (e.g., in some CI environments)
+      console.warn('Skipping test: no gh-pages cache directory available');
+      return;
+    }
+
+    // Create a fake repo-specific cache directory
+    const fakeRepoUrl = 'https://github.com/test/clean-test.git';
+    const repoCacheDir = path.join(cacheBaseDir, filenamify(fakeRepoUrl, { replacement: '!' }));
+
+    // Setup: create the fake cache directory with a marker file
+    await fs.mkdir(repoCacheDir, { recursive: true });
+    await fs.writeFile(path.join(repoCacheDir, 'marker.txt'), 'should be deleted');
+    expect(await pathExists(repoCacheDir)).toBe(true);
+
+    // Execute clean - this removes ALL repo cache directories
+    ghPages.clean();
+
+    // Verify the directory was removed
+    expect(await pathExists(repoCacheDir)).toBe(false);
+  });
+
+  it('should not throw when cache directory does not exist', () => {
+    // clean() should be safe to call even if nothing to clean
+    expect(() => ghPages.clean()).not.toThrow();
+  });
+});

--- a/src/engine/engine.gh-pages-integration.spec.ts
+++ b/src/engine/engine.gh-pages-integration.spec.ts
@@ -14,11 +14,10 @@ import { logging } from '@angular-devkit/core';
 import * as engine from './engine';
 import { cleanupMonkeypatch } from './engine.prepare-options-helpers';
 
-// Mock fs-extra at module level to avoid conflicts with other test files
-jest.mock('fs-extra', () => ({
-  pathExists: jest.fn().mockResolvedValue(true),
-  writeFile: jest.fn().mockResolvedValue(undefined),
-  copy: jest.fn().mockResolvedValue(undefined)
+// Mock utils.pathExists at module level
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  pathExists: jest.fn().mockResolvedValue(true)
 }));
 
 // Mock Git class from gh-pages to avoid spawning actual git processes

--- a/src/engine/engine.prepare-options-helpers.spec.ts
+++ b/src/engine/engine.prepare-options-helpers.spec.ts
@@ -637,8 +637,9 @@ describe('prepareOptions helpers - intensive tests', () => {
     it('should throw helpful error when not in a git repository', async () => {
       // Change to a non-git directory
       const originalCwd = process.cwd();
+      const fs = require('fs/promises');
       const tempDir = path.join(require('os').tmpdir(), 'not-a-git-repo-test-' + Date.now());
-      await require('fs-extra').ensureDir(tempDir);
+      await fs.mkdir(tempDir, { recursive: true });
 
       try {
         process.chdir(tempDir);
@@ -651,7 +652,7 @@ describe('prepareOptions helpers - intensive tests', () => {
           .toThrow('Failed to get remote.origin.url (task must either be run in a git repository with a configured origin remote or must be configured with the "repo" option).');
       } finally {
         process.chdir(originalCwd);
-        await require('fs-extra').remove(tempDir);
+        await fs.rm(tempDir, { recursive: true, force: true });
       }
     });
   });

--- a/src/engine/engine.spec.ts
+++ b/src/engine/engine.spec.ts
@@ -174,8 +174,9 @@ describe('engine', () => {
         publish: jest.fn()
       }));
 
-      const fse = require('fs-extra');
-      jest.spyOn(fse, 'pathExists').mockResolvedValue(false);
+      // Mock pathExists from utils to return false
+      const utils = require('../utils');
+      jest.spyOn(utils, 'pathExists').mockResolvedValue(false);
 
       const nonExistentDir = '/path/to/nonexistent/dir';
       const expectedErrorMessage = 'Dist folder does not exist. Check the dir --dir parameter or build the project first!';
@@ -184,7 +185,7 @@ describe('engine', () => {
         engine.run(nonExistentDir, { dotfiles: true, notfound: true, nojekyll: true }, logger)
       ).rejects.toThrow(expectedErrorMessage);
 
-      expect(fse.pathExists).toHaveBeenCalledWith(nonExistentDir);
+      expect(utils.pathExists).toHaveBeenCalledWith(nonExistentDir);
     });
   });
 
@@ -256,16 +257,14 @@ describe('engine', () => {
     // We now use await ghPages.publish() directly instead of callback-based approach
     const logger = new logging.NullLogger();
 
-    let fsePathExistsSpy: jest.SpyInstance;
-    let fseWriteFileSpy: jest.SpyInstance;
+    let pathExistsSpy: jest.SpyInstance;
     let ghpagesCleanSpy: jest.SpyInstance;
     let ghpagesPublishSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      // Setup persistent mocks for fs-extra
-      const fse = require('fs-extra');
-      fsePathExistsSpy = jest.spyOn(fse, 'pathExists').mockResolvedValue(true);
-      fseWriteFileSpy = jest.spyOn(fse, 'writeFile').mockResolvedValue(undefined);
+      // Setup persistent mocks for utils.pathExists
+      const utils = require('../utils');
+      pathExistsSpy = jest.spyOn(utils, 'pathExists').mockResolvedValue(true);
 
       // Setup persistent mocks for gh-pages
       const ghpages = require('gh-pages');
@@ -275,8 +274,7 @@ describe('engine', () => {
 
     afterEach(() => {
       // Clean up spies
-      fsePathExistsSpy.mockRestore();
-      fseWriteFileSpy.mockRestore();
+      pathExistsSpy.mockRestore();
       ghpagesCleanSpy.mockRestore();
       ghpagesPublishSpy.mockRestore();
     });

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,8 +1,9 @@
 import {logging} from '@angular-devkit/core';
-import * as fse from 'fs-extra';
+import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import {Schema} from '../deploy/schema';
+import {pathExists} from '../utils';
 import {GHPages, PublishOptions} from '../interfaces';
 import {defaults} from './defaults';
 import {
@@ -100,10 +101,7 @@ export async function prepareOptions(
 }
 
 async function checkIfDistFolderExists(dir: string) {
-  // CRITICAL FIX: Operator precedence bug
-  // WRONG: await !fse.pathExists(dir) - applies ! to Promise (always false)
-  // RIGHT: !(await fse.pathExists(dir)) - awaits first, then negates boolean
-  if (!(await fse.pathExists(dir))) {
+  if (!await pathExists(dir)) {
     throw new Error(
       'Dist folder does not exist. Check the dir --dir parameter or build the project first!'
     );
@@ -134,7 +132,7 @@ async function createNotFoundFile(
   const notFoundFile = path.join(dir, '404.html');
 
   try {
-    await fse.copy(indexHtml, notFoundFile);
+    await fs.copyFile(indexHtml, notFoundFile);
     logger.info('404.html file created');
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -2,5 +2,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  modulePathIgnorePatterns: ['<rootDir>/dist/package.json']
+  modulePathIgnorePatterns: ['<rootDir>/dist/package.json'],
+  // Run tests serially to avoid ghPages.clean() race conditions
+  // engine.gh-pages-clean.spec.ts calls ghPages.clean() which affects ALL cache dirs
+  maxWorkers: 1
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "2.1.0",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-cli-ghpages",
-      "version": "2.1.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": ">=0.1800.0",
-        "@angular-devkit/core": ">=18.0.0",
-        "@angular-devkit/schematics": ">=18.0.0",
-        "fs-extra": "^11.2.0",
+        "@angular-devkit/architect": ">=0.1800.0 <0.2200.0",
+        "@angular-devkit/core": ">=18.0.0 <22.0.0",
+        "@angular-devkit/schematics": ">=18.0.0 <22.0.0",
         "gh-pages": "6.3.0"
       },
       "bin": {
@@ -23,7 +22,6 @@
         "@angular-devkit/architect": "~0.1800.0",
         "@angular-devkit/core": "^18.0.0",
         "@angular-devkit/schematics": "^18.0.0",
-        "@types/fs-extra": "^11.0.4",
         "@types/jest": "^29.5.11",
         "@types/node": "^20.11.7",
         "copyfiles": "^2.4.1",
@@ -38,7 +36,7 @@
         "npm": ">=9.0.0"
       },
       "peerDependencies": {
-        "@angular/cli": ">=18.0.0"
+        "@angular/cli": ">=18.0.0 <22.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -3292,16 +3290,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -3360,15 +3348,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.202",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Deploy your Angular app to GitHub Pages or Cloudflare Pages directly from the Angular CLI (ng deploy)",
   "main": "index.js",
   "types": "index.d.ts",
@@ -61,7 +61,6 @@
     "@angular-devkit/architect": "~0.1800.0",
     "@angular-devkit/core": "^18.0.0",
     "@angular-devkit/schematics": "^18.0.0",
-    "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.7",
     "copyfiles": "^2.4.1",
@@ -75,7 +74,6 @@
     "@angular-devkit/architect": ">=0.1800.0 <0.2200.0",
     "@angular-devkit/core": ">=18.0.0 <22.0.0",
     "@angular-devkit/schematics": ">=18.0.0 <22.0.0",
-    "fs-extra": "^11.2.0",
     "gh-pages": "6.3.0"
   },
   "peerDependencies": {

--- a/src/parameter-tests/builder-integration.spec.ts
+++ b/src/parameter-tests/builder-integration.spec.ts
@@ -20,7 +20,7 @@ import { cleanupMonkeypatch } from '../engine/engine.prepare-options-helpers';
  *
  * WHAT'S REAL vs MOCKED:
  * ✅ REAL: deploy/actions.ts, engine/engine.ts, prepareOptions()
- * ❌ MOCKED: gh-pages.publish() (to capture final options), fs-extra, gh-pages/lib/git
+ * ❌ MOCKED: gh-pages.publish() (to capture final options), utils.pathExists, gh-pages/lib/git
  * This IS a true integration test - we test the full internal code path with external dependencies mocked.
  */
 
@@ -43,43 +43,10 @@ jest.mock('gh-pages', () => ({
   })
 }));
 
-// Mock fs module
-jest.mock('fs', () => ({
-  existsSync: jest.fn(() => true),
-  writeFileSync: jest.fn(),
-  readFileSync: jest.fn(() => ''),
-  mkdirSync: jest.fn(),
-  readdirSync: jest.fn(() => []),
-  statSync: jest.fn(() => ({ isDirectory: () => false })),
-  promises: {
-    readFile: jest.fn(() => Promise.resolve('')),
-    writeFile: jest.fn(() => Promise.resolve()),
-  },
-  native: {} // For fs-extra
-}));
-
-// Mock fs-extra module (it extends fs)
-jest.mock('fs-extra', () => ({
-  existsSync: jest.fn(() => true),
-  writeFileSync: jest.fn(),
-  writeFile: jest.fn(() => Promise.resolve()),
-  readFileSync: jest.fn(() => ''),
-  readFile: jest.fn(() => Promise.resolve('')),
-  mkdirSync: jest.fn(),
-  readdirSync: jest.fn(() => []),
-  statSync: jest.fn(() => ({ isDirectory: () => false })),
-  promises: {
-    readFile: jest.fn(() => Promise.resolve('')),
-    writeFile: jest.fn(() => Promise.resolve()),
-  },
-  native: {},
-  ensureDirSync: jest.fn(),
-  emptyDirSync: jest.fn(),
-  copy: jest.fn(() => Promise.resolve()),
-  copySync: jest.fn(),
-  removeSync: jest.fn(),
-  pathExists: jest.fn(() => Promise.resolve(true)),
-  pathExistsSync: jest.fn(() => true),
+// Mock utils.pathExists
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  pathExists: jest.fn(() => Promise.resolve(true))
 }));
 
 // Import after mocking

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for utils.ts
+ */
+
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createHost, pathExists } from './utils';
+
+describe('createHost', () => {
+  it('should read file from tree', async () => {
+    const tree = Tree.empty();
+    tree.create('/test.txt', 'hello world');
+
+    const host = createHost(tree);
+    const content = await host.readFile('/test.txt');
+
+    expect(content).toBe('hello world');
+  });
+
+  it('should throw SchematicsException when file not found', async () => {
+    const tree = Tree.empty();
+    const host = createHost(tree);
+
+    await expect(host.readFile('/nonexistent.txt')).rejects.toThrow(SchematicsException);
+    await expect(host.readFile('/nonexistent.txt')).rejects.toThrow('File not found.');
+  });
+
+  it('should write file to tree', async () => {
+    const tree = Tree.empty();
+    tree.create('/test.txt', 'original');
+
+    const host = createHost(tree);
+    await host.writeFile('/test.txt', 'updated');
+
+    expect(tree.read('/test.txt')?.toString()).toBe('updated');
+  });
+
+  it('should detect file as file', async () => {
+    const tree = Tree.empty();
+    tree.create('/file.txt', 'content');
+
+    const host = createHost(tree);
+
+    expect(await host.isFile('/file.txt')).toBe(true);
+  });
+
+  it('should detect non-existing path as not a file', async () => {
+    const tree = Tree.empty();
+    const host = createHost(tree);
+
+    expect(await host.isFile('/nonexistent.txt')).toBe(false);
+  });
+
+  it('should detect directory as directory', async () => {
+    const tree = Tree.empty();
+    tree.create('/subdir/file.txt', 'content');
+
+    const host = createHost(tree);
+
+    expect(await host.isDirectory('/subdir')).toBe(true);
+  });
+
+  it('should detect file as not a directory', async () => {
+    const tree = Tree.empty();
+    tree.create('/file.txt', 'content');
+
+    const host = createHost(tree);
+
+    expect(await host.isDirectory('/file.txt')).toBe(false);
+  });
+});
+
+describe('pathExists', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pathExists-test-'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return true for existing directory', async () => {
+    expect(await pathExists(tempDir)).toBe(true);
+  });
+
+  it('should return true for existing file', async () => {
+    const filePath = path.join(tempDir, 'test.txt');
+    await fs.writeFile(filePath, 'test');
+
+    expect(await pathExists(filePath)).toBe(true);
+  });
+
+  it('should return false for non-existing path', async () => {
+    const nonExistentPath = path.join(tempDir, 'does-not-exist');
+
+    expect(await pathExists(nonExistentPath)).toBe(false);
+  });
+
+  it('should return false for non-existing nested path', async () => {
+    const nonExistentPath = '/nonexistent/path/12345/foo/bar';
+
+    expect(await pathExists(nonExistentPath)).toBe(false);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,18 @@
-import { virtualFs, workspaces } from '@angular-devkit/core';
+import { workspaces } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as fs from 'fs/promises';
+
+/**
+ * Check if a path exists (replacement for fs-extra.pathExists)
+ */
+export async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function createHost(tree: Tree): workspaces.WorkspaceHost {
   return {
@@ -8,7 +21,7 @@ export function createHost(tree: Tree): workspaces.WorkspaceHost {
       if (!data) {
         throw new SchematicsException('File not found.');
       }
-      return virtualFs.fileBufferToString(data);
+      return data.toString('utf-8');
     },
     async writeFile(path: string, data: string): Promise<void> {
       return tree.overwrite(path, data);


### PR DESCRIPTION
## Summary

- Remove `fs-extra` dependency in favor of native `fs/promises`
- Fewer dependencies = fewer supply chain attack vectors

## Changes

- Added `pathExists()` utility using native `fs.access()`
- Replaced `fse.copy()` with `fs.copyFile()`
- Replaced `fse.ensureDir()` with `fs.mkdir({ recursive: true })`
- Updated all tests to use native fs/promises
- Tests run serially now (`maxWorkers: 1`) to avoid `ghPages.clean()` race conditions
- New `engine.gh-pages-clean.spec.ts` verifies clean() behavior for future gh-pages upgrades