### PR TITLE
fix: set CACHE_DIR fallback when no package.json is reachable (#203)

### DIFF
--- a/src/engine/engine.gh-pages-no-package-json.spec.ts
+++ b/src/engine/engine.gh-pages-no-package-json.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * End-to-end integration test for issue #203 — REAL git, REAL gh-pages, REAL filesystem.
+ *
+ * Reproduces the original failure ("path argument must be of type string ... Received
+ * undefined") that happens when `angular-cli-ghpages` runs in a directory with no
+ * `package.json` in any parent — typical for `npx angular-cli-ghpages` on a repo
+ * that is just a `dist/` folder.
+ *
+ * Root cause: gh-pages@6.3.0 uses `find-cache-dir` to determine where to clone.
+ * `find-cache-dir` walks up looking for `package.json`; if it finds none, it
+ * returns `undefined`, and gh-pages then does `path.join(undefined, ...)`.
+ *
+ * Fix: engine.run() calls `ensureGhPagesCacheDir()` before loading gh-pages,
+ * which sets `CACHE_DIR` to an os.tmpdir() fallback when no `package.json` is
+ * reachable. `find-cache-dir` honors `CACHE_DIR` as an explicit override.
+ *
+ * Flow:
+ *   1. Make a local bare repo and seed a gh-pages branch with one file.
+ *   2. Create a cwd that has NO package.json in any ancestor (os.mkdtemp).
+ *   3. `process.chdir()` there so engine.run() / gh-pages see that cwd.
+ *   4. Run engine.run().
+ *   5. Assert no throw AND the new dist file lands in the remote.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { execSync } from 'child_process';
+
+import { logging } from '@angular-devkit/core';
+
+import * as engine from './engine';
+import { cleanupMonkeypatch } from './engine.prepare-options-helpers';
+
+// NO MOCKS — we want real gh-pages behavior end-to-end.
+const ghPages = require('gh-pages');
+
+function git(args: string, cwd: string): string {
+  return execSync(`git -C "${cwd}" ${args}`, { stdio: ['pipe', 'pipe', 'pipe'] })
+    .toString()
+    .trim();
+}
+
+describe('engine.run() in a directory with no package.json (issue #203)', () => {
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let workDir: string;       // Outside any package.json tree; becomes cwd.
+  let bareRepoPath: string;
+  let distDir: string;
+
+  beforeEach(async () => {
+    cleanupMonkeypatch();
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    delete process.env.CACHE_DIR;
+    delete process.env.TRAVIS;
+    delete process.env.CIRCLECI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.GH_TOKEN;
+    delete process.env.PERSONAL_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghp-203-e2e-'));
+
+    // Dist with just index.html. Note: no package.json is ever created in workDir.
+    distDir = path.join(workDir, 'dist');
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(path.join(distDir, 'index.html'), '<html>fresh</html>\n');
+
+    // Bare repo + seed a gh-pages branch so gh-pages' clone + checkout succeed.
+    bareRepoPath = path.join(workDir, 'bare.git');
+    execSync(`git init --bare "${bareRepoPath}"`, { stdio: 'pipe' });
+
+    const seedDir = path.join(workDir, 'seed');
+    await fs.mkdir(seedDir, { recursive: true });
+    execSync(`git init "${seedDir}"`, { stdio: 'pipe' });
+    git('config user.email "seed@test.com"', seedDir);
+    git('config user.name "Seed"', seedDir);
+    git('checkout -b gh-pages', seedDir);
+    await fs.writeFile(path.join(seedDir, 'old.html'), '<html>old</html>');
+    git('add .', seedDir);
+    git('commit -m "seed"', seedDir);
+    git(`remote add origin "${bareRepoPath}"`, seedDir);
+    git('push origin gh-pages', seedDir);
+
+    ghPages.clean();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    ghPages.clean();
+    cleanupMonkeypatch();
+    await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  it('engine.run() succeeds and actually publishes when no package.json is reachable from cwd', async () => {
+    // This test exists because spawn-mock or unit coverage cannot prove the
+    // full chain (prepareOptions → ensureGhPagesCacheDir → require("gh-pages")
+    // → gh-pages.clean() → gh-pages.publish() → real git clone/push). Only a
+    // real run can.
+
+    process.chdir(workDir);
+
+    await engine.run(
+      distDir,
+      {
+        repo: bareRepoPath,
+        branch: 'gh-pages',
+        dotfiles: true,
+        notfound: false,
+        nojekyll: false,
+        name: 'Test',
+        email: 'test@test.com',
+        message: 'test deploy (no package.json)'
+      },
+      new logging.NullLogger()
+    );
+
+    // Would-have-been-the-bug: if ensureGhPagesCacheDir didn't run or failed,
+    // gh-pages.clean() / publish() would have thrown the "path ... Received
+    // undefined" TypeError before reaching here.
+
+    // Positive proof that the deploy actually landed:
+    const tree = git('ls-tree -r gh-pages --name-only', bareRepoPath)
+      .split('\n')
+      .filter(Boolean)
+      .sort();
+    expect(tree).toEqual(['index.html']);
+
+    // And CACHE_DIR was set to our tmpdir fallback (not some boolean-ish or empty).
+    expect(process.env.CACHE_DIR).toBe(path.join(os.tmpdir(), 'angular-cli-ghpages-cache'));
+  }, 30_000);
+
+  it('baseline: bare gh-pages.clean() in a no-package-json cwd throws the #203 error (fresh child process)', () => {
+    // Run in a separate Node process so there is no shared require.cache / env
+    // pollution from the primary test. This proves the upstream bug is real —
+    // NOT a mock story.
+    const ghPagesPath = require.resolve('gh-pages');
+    const script =
+      `process.chdir(${JSON.stringify(workDir)});` +
+      `const ghPages = require(${JSON.stringify(ghPagesPath)});` +
+      `try { ghPages.clean(); console.log('NOTHROW'); process.exit(1); }` +
+      `catch (e) { process.stdout.write(String(e && e.message)); process.exit(0); }`;
+
+    // Explicitly unset CACHE_DIR in the child's env so find-cache-dir must
+    // fall back to the package.json walk (which finds nothing here).
+    const childEnv = { ...process.env };
+    delete childEnv.CACHE_DIR;
+
+    const out = execSync(`node -e ${JSON.stringify(script)}`, {
+      cwd: workDir,
+      env: childEnv,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).toString();
+
+    expect(out).toMatch(/must be of type string|Received undefined/);
+  }, 10_000);
+});

--- a/src/engine/engine.prepare-options-helpers.spec.ts
+++ b/src/engine/engine.prepare-options-helpers.spec.ts
@@ -5,6 +5,8 @@
  * by testing each helper function independently.
  */
 
+import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import { logging } from '@angular-devkit/core';
 
@@ -635,7 +637,7 @@ describe('prepareOptions helpers - intensive tests', () => {
     });
 
     it('should throw helpful error when not in a git repository', async () => {
-      // Change to a non-git directory
+      // Change to a non-git directory (also incidentally exercises ensureGhPagesCacheDir via engine.run elsewhere)
       const originalCwd = process.cwd();
       const fs = require('fs/promises');
       const tempDir = path.join(require('os').tmpdir(), 'not-a-git-repo-test-' + Date.now());
@@ -653,6 +655,68 @@ describe('prepareOptions helpers - intensive tests', () => {
       } finally {
         process.chdir(originalCwd);
         await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('ensureGhPagesCacheDir - find-cache-dir fallback (issue #203)', () => {
+    // Each test must explicitly manage CACHE_DIR because the outer beforeEach
+    // clones `originalEnv` but does NOT delete CACHE_DIR.
+    beforeEach(() => {
+      delete process.env.CACHE_DIR;
+    });
+
+    it('sets CACHE_DIR to an os.tmpdir() fallback when cwd has no package.json', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ghp-203-unit-'));
+      try {
+        helpers.ensureGhPagesCacheDir(tmp);
+        expect(process.env.CACHE_DIR).toBeDefined();
+        // Must be inside os.tmpdir() and non-empty
+        expect(process.env.CACHE_DIR!.startsWith(os.tmpdir())).toBe(true);
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('does NOT set CACHE_DIR when cwd has a reachable package.json', () => {
+      // This repo root (parent of __dirname) has a package.json, so find-cache-dir succeeds.
+      const repoDir = path.resolve(__dirname, '..');
+      helpers.ensureGhPagesCacheDir(repoDir);
+      expect(process.env.CACHE_DIR).toBeUndefined();
+    });
+
+    it('respects a user-set CACHE_DIR (does not overwrite)', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ghp-203-respect-'));
+      try {
+        const userChosen = '/user/chosen/cache';
+        process.env.CACHE_DIR = userChosen;
+        helpers.ensureGhPagesCacheDir(tmp);
+        expect(process.env.CACHE_DIR).toBe(userChosen);
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('DOES apply fallback when CACHE_DIR is a boolean-ish value (matches find-cache-dir semantics)', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ghp-203-boolish-'));
+      try {
+        process.env.CACHE_DIR = 'true'; // find-cache-dir treats this as "unset"
+        helpers.ensureGhPagesCacheDir(tmp);
+        expect(process.env.CACHE_DIR).not.toBe('true');
+        expect(process.env.CACHE_DIR!.startsWith(os.tmpdir())).toBe(true);
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('fallback path is inside os.tmpdir() and includes our namespace', async () => {
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ghp-203-ns-'));
+      try {
+        helpers.ensureGhPagesCacheDir(tmp);
+        expect(process.env.CACHE_DIR).toBeDefined();
+        expect(process.env.CACHE_DIR!).toBe(path.join(os.tmpdir(), 'angular-cli-ghpages-cache'));
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true });
       }
     });
   });

--- a/src/engine/engine.prepare-options-helpers.ts
+++ b/src/engine/engine.prepare-options-helpers.ts
@@ -7,6 +7,7 @@
 
 import { logging } from '@angular-devkit/core';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 import * as util from 'util';
 
@@ -73,6 +74,68 @@ export function cleanupMonkeypatch(): void {
     utilMutable.debuglog = originalDebuglog;
     originalDebuglog = null;
   }
+}
+
+/**
+ * Ensure gh-pages' internal `find-cache-dir` call resolves to a real path.
+ *
+ * gh-pages@6.3.0 calls `findCacheDir({ name: 'gh-pages' })` for both `clean()`
+ * and `publish()`. `find-cache-dir` walks up from cwd looking for a
+ * `package.json`; if none is found (e.g. `npx angular-cli-ghpages` run in a
+ * repo that is just a `dist/` folder), it returns `undefined`, and gh-pages
+ * then blows up with `TypeError: The "path" argument must be of type string
+ * ... Received undefined` inside `path.join(undefined, ...)`.
+ *
+ * Workaround: `find-cache-dir` honors the `CACHE_DIR` env var — if set (and
+ * not a boolean-ish value), it returns `path.join(CACHE_DIR, name)` without
+ * any package.json lookup. We set it to an os.tmpdir() fallback, but only
+ * when (a) the user hasn't already set it themselves, and (b) no package.json
+ * is reachable from cwd. See issue #203.
+ *
+ * We don't use find-cache-dir to probe because it captures `process.env` by
+ * reference at module load and is then cached in `require.cache`; that makes
+ * it brittle under test reassignment of `process.env`.
+ *
+ * MUST run before gh-pages' `clean()` / `publish()` invoke find-cache-dir.
+ */
+export function ensureGhPagesCacheDir(cwd: string = process.cwd()): void {
+  // Respect a user-set CACHE_DIR. find-cache-dir itself treats boolean-ish
+  // values as "not set" (it opts out of its early return), so mirror that.
+  const existing = process.env.CACHE_DIR;
+  if (existing && !['true', 'false', '1', '0'].includes(existing)) {
+    return;
+  }
+
+  if (hasReachablePackageJson(cwd)) {
+    return;
+  }
+
+  // Stable, per-user fallback location. gh-pages itself creates
+  // `<CACHE_DIR>/gh-pages/<filenamify(repo)>` underneath this.
+  process.env.CACHE_DIR = path.join(os.tmpdir(), 'angular-cli-ghpages-cache');
+}
+
+/**
+ * Walk up from `startDir` looking for a `package.json`. Mirrors what
+ * pkg-dir/find-cache-dir do internally, but avoids their module-level
+ * `process.env` caching (see `ensureGhPagesCacheDir`).
+ */
+function hasReachablePackageJson(startDir: string): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fsSync = require('fs');
+  let dir = path.resolve(startDir);
+  // Safety cap against pathological infinite loops; real trees are <50 deep.
+  for (let i = 0; i < 50; i++) {
+    if (fsSync.existsSync(path.join(dir, 'package.json'))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return false;
+    }
+    dir = parent;
+  }
+  return false;
 }
 
 /**

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -14,7 +14,8 @@ import {
   warnDeprecatedParameters,
   appendCIMetadata,
   injectTokenIntoRepoUrl,
-  createCleanupBeforeAddHook
+  createCleanupBeforeAddHook,
+  ensureGhPagesCacheDir
 } from './engine.prepare-options-helpers';
 
 export async function run(
@@ -23,6 +24,12 @@ export async function run(
   logger: logging.LoggerApi
 ) {
   options = await prepareOptions(options, logger);
+
+  // Provide a cache-dir fallback when there's no package.json in cwd
+  // (e.g. `npx angular-cli-ghpages` in a static-content repo). Without this,
+  // gh-pages' internal find-cache-dir returns undefined and path.join throws.
+  // See issue #203. Must run before the first find-cache-dir call.
+  ensureGhPagesCacheDir();
 
   // CRITICAL: Must require gh-pages AFTER monkeypatching util.debuglog
   // gh-pages calls util.debuglog('gh-pages') during module initialization to set up its logger.

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-cli-ghpages",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": ">=0.1800.0 <0.2200.0",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "3.0.5",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-cli-ghpages",
-      "version": "3.0.5",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": ">=0.1800.0 <0.2200.0",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "3.0.5",
+  "version": "3.0.3",
   "description": "Deploy your Angular app to GitHub Pages or Cloudflare Pages directly from the Angular CLI (ng deploy)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-ghpages",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Deploy your Angular app to GitHub Pages or Cloudflare Pages directly from the Angular CLI (ng deploy)",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Fixes #203 — `npx angular-cli-ghpages --dir=dist --branch=gh-pages` in a directory with no `package.json` (e.g. a repo that is just a static `dist/` folder) fails with:

```
❌ An error occurred when trying to deploy:
The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
```

## Root cause

gh-pages@6.3.0 calls `find-cache-dir({ name: 'gh-pages' })` in both `clean()` and `publish()`. `find-cache-dir` walks up from cwd looking for `package.json` — if it finds none, it returns `undefined`. gh-pages then does `path.join(undefined, filenamify(repo))` → `TypeError`.

The reporter's workaround `npm install angular-cli-ghpages` works because it creates a `package.json` as a side effect, which `find-cache-dir` can then find.

## Fix

`find-cache-dir` honors the `CACHE_DIR` env var as an explicit override — when set (and not a boolean-ish `'true'/'false'/'1'/'0'`), it short-circuits the `package.json` walk and returns `path.join(CACHE_DIR, name)` directly.

New helper `ensureGhPagesCacheDir()` in `engine.prepare-options-helpers.ts`:

1. Respects a user-set `CACHE_DIR` (no-op).
2. Probes for a reachable `package.json` via our own synchronous walker.
3. If none is found, sets `process.env.CACHE_DIR = <os.tmpdir()>/angular-cli-ghpages-cache`.

Called from `engine.run()` before `require('gh-pages')`.

We probe for `package.json` ourselves instead of delegating to `find-cache-dir` because `find-cache-dir` captures `const {env} = process` at module load and is then cached in `require.cache` — using it as our probe makes behavior brittle under test `process.env` reassignment.
